### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ wsm.wss.send('somthing');
 
 ```html
 
-<script src="https://cdn.jsdelivr.net/wsm/1.0.5/wsm.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/wsm@2.0.0/lib/wsm.js"></script>
 <script>
     //reactive function for websocket manager, this will include all the handlers
     function reactive(wsm){


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/wsm.

Feel free to ping me if you have any questions regarding this change.